### PR TITLE
Reusable workflow to build and optionally publish docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,11 +2,13 @@ name: Build and publish docker images
 on:
   workflow_call:
     inputs:
-      arm64:
-        description: If set to true, build an image for arm64 as well as amd64.
-        type: boolean
+      platforms:
+        description: > 
+          Specify which platforms to build an image for. Forwarded to 
+          docker/build-push-action@v2.
+        type: string
         required: false
-        default: false
+        default: linux/amd64,linux/arm64
       image-name:
         description: "What to call the docker image. This is the FOO in 'matrixdotorg/FOO:tagname'"
         type: string
@@ -35,8 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        if: ${{ inputs.arm64 }}
-        id: qemu
+        if: contains(inputs.platform, 'linux/arm64')
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64
@@ -75,21 +76,11 @@ jobs:
           esac
           echo "::set-output name=tag::$tag"
 
-      - name: Build and push amd64
+      - name: Build and push images
         uses: docker/build-push-action@v2
         with:
           push: ${{ inputs.publish }}
           labels: "gitsha1=${{ github.sha }}"
           tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
           file: ${{ inputs.dockerfile }}
-          platforms: linux/amd64
-
-      - name: Build and push arm64
-        if: ${{ inputs.arm64 }}
-        uses: docker/build-push-action@v2
-        with:
-          push: ${{ inputs.publish }}
-          labels: "gitsha1=${{ github.sha }}"
-          tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
-          file: ${{ inputs.dockerfile }}
-          platforms: linux/arm64
+          platforms: ${{ inputs.platforms }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        if: contains(inputs.platform, 'linux/arm64')
+        if: contains(inputs.platforms, 'linux/arm64')
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,92 @@
+name: Build and publish docker images
+on:
+  workflow_call:
+    inputs:
+      arm64:
+        description: If set to true, build an image for arm64 as well as amd64.
+        type: boolean
+        required: false
+        default: false
+      image-name:
+        description: "What to call the docker image. This is the FOO in 'matrixdotorg/FOO:tagname'"
+        type: string
+        required: true
+      dockerfile:
+        description: Path to the Dockerfile, relative to the repository root.
+        type: string
+        required: false
+        default: Dockerfile
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        if: ${{ inputs.arm64 }}
+        id: qemu
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Inspect builder
+        run: docker buildx inspect
+          
+      - name: Log in to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # TODO: consider using https://github.com/docker/metadata-action instead of this
+      # custom magic
+      - name: Calculate docker image tag
+        id: set-tag
+        run: |
+          case "${GITHUB_REF}" in
+              refs/heads/develop)
+                  tag=develop
+                  ;;
+              refs/heads/master|refs/heads/main)
+                  tag=latest
+                  ;;
+              refs/tags/*)
+                  tag=${GITHUB_REF#refs/tags/}
+                  ;;
+              *)
+                  tag=${GITHUB_SHA}
+                  ;;
+          esac
+          echo "::set-output name=tag::$tag"
+
+      - name: Build and push amd64
+        uses: docker/build-push-action@v2
+        with:
+#          push: true
+          push: false
+          labels: "gitsha1=${{ github.sha }}"
+          tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/amd64
+
+      - name: Build and push arm64
+        if: ${{ inputs.arm64 }}
+        uses: docker/build-push-action@v2
+        with:
+          #          push: true
+          push: false
+          labels: "gitsha1=${{ github.sha }}"
+          tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
+          file: ${{ inputs.dockerfile }}
+          platforms: linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,11 @@
+# Build and publish docker images.
+#
+# Callers have to opt-in to publishing by passing
+#
+#   with:
+#     publish: true
+#
+# Without publish: true, you can use this workflow to prototype building the image.
 name: Build and publish docker images
 on:
   workflow_call:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,11 @@ on:
         type: string
         required: false
         default: Dockerfile
+      publish:
+        description: If true, publish to dockerhub.
+        type: boolean
+        required: false
+        default: false
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -73,8 +78,7 @@ jobs:
       - name: Build and push amd64
         uses: docker/build-push-action@v2
         with:
-#          push: true
-          push: false
+          push: ${{ inputs.publish }}
           labels: "gitsha1=${{ github.sha }}"
           tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
           file: ${{ inputs.dockerfile }}
@@ -84,8 +88,7 @@ jobs:
         if: ${{ inputs.arm64 }}
         uses: docker/build-push-action@v2
         with:
-          #          push: true
-          push: false
+          push: ${{ inputs.publish }}
           labels: "gitsha1=${{ github.sha }}"
           tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        if: contains(inputs.platforms, 'linux/arm64')
+        if: inputs.platforms != 'linux/amd64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Log in to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       # TODO: consider using https://github.com/docker/metadata-action instead of this
       # custom magic

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,13 +2,6 @@ name: Build and publish docker images
 on:
   workflow_call:
     inputs:
-      platforms:
-        description: > 
-          Specify which platforms to build an image for. Forwarded to 
-          docker/build-push-action@v2.
-        type: string
-        required: false
-        default: linux/amd64,linux/arm64
       image-name:
         description: >
           What to call the docker image. Does not include a tag name. You need to 
@@ -39,7 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        if: inputs.platforms != 'linux/amd64'
         uses: docker/setup-qemu-action@v1
         with:
           platforms: arm64
@@ -85,4 +77,4 @@ jobs:
           labels: "gitsha1=${{ github.sha }}"
           tags: "${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
           file: ${{ inputs.dockerfile }}
-          platforms: ${{ inputs.platforms }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,9 +26,9 @@ on:
         required: false
         default: false
     secrets:
-      DOCKERHUB_USERNAME:
+      DOCKER_HUB_USERNAME:
         required: true
-      DOCKERHUB_TOKEN:
+      DOCKER_HUB_TOKEN:
         required: true
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,9 @@ on:
         required: false
         default: linux/amd64,linux/arm64
       image-name:
-        description: "What to call the docker image. This is the FOO in 'matrixdotorg/FOO:tagname'"
+        description: >
+          What to call the docker image. Does not include a tag name. You need to 
+          include the 'matrixdotorg/' prefix.
         type: string
         required: true
       dockerfile:
@@ -81,6 +83,6 @@ jobs:
         with:
           push: ${{ inputs.publish }}
           labels: "gitsha1=${{ github.sha }}"
-          tags: "matrixdotorg/${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
+          tags: "${{ inputs.image-name }}:${{ steps.set-tag.outputs.tag }}"
           file: ${{ inputs.dockerfile }}
           platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
Cribbed from Synapse's config.

After some back-and-forth, I decided to always build amd64 and arm64 to keep things simple.

If I'm following the recommended branch and tag system recommended for github actions, then I think I need to

- merge this to main
- fast forward releases/v1 to the merged commit
- force push the v1 tag to the merged commit too