### PR TITLE
Workflow to publish to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+# See also https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ 
+
+name: "Build and upload to PyPI"
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: "The package repository to upload to. Defaults to 'testpypi'; use 'pypi' for the regular package index."
+        type: string
+        required: false
+        default: "testpypi"
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
+
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.x"
+
+      - name: "Install packaging tools"
+        run: "python -m pip install build twine"
+
+      - name: "Build dist package"
+        run: "python -m build"
+
+      - name: "Upload to PyPI"
+        run: "python -m twine upload dist/*"
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: "${{ secrets.PYPI_API_TOKEN }}"
+          TWINE_REPOSITORY: "${{ inputs.repository }}"


### PR DESCRIPTION
Spun out to a generic workflow, see https://github.com/matrix-org/synapse-module-cookiecutter-template/pull/23#issuecomment-1012389846