### PR TITLE
Pin mypy cache action to hash, not tag

### DIFF
--- a/.github/workflows/python-poetry-ci.yml
+++ b/.github/workflows/python-poetry-ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: matrix-org/setup-python-poetry@v1
 
       - name: Restore/persist mypy's cache
-        uses: AustinScola/mypy-cache-github-action@v1
+        uses: AustinScola/mypy-cache-github-action@df56268388422ee282636ee2c7a9cc55ec644a41
 
       - name: Run mypy
         run: poetry run mypy


### PR DESCRIPTION
Authors are only supposed to update actions' tags in a semver compatible
way. But since this is an external action and not one that we control,
let's be more paranoid and pin this to a particular commit hash.