### PR TITLE
Allow extras to be installed for typechecking

### DIFF
--- a/.github/workflows/python-poetry-ci.yml
+++ b/.github/workflows/python-poetry-ci.yml
@@ -1,6 +1,18 @@
 name: Linting
 on:
   workflow_call:
+    inputs:
+      typechecking-extras:
+        description: >
+          Space-separated list of package extras to install when type checking.
+          (I.e. the entries in `pyproject.toml`'s `[tool.poetry.extras]` section.)
+          Defaults to no extras.
+        # In the future I'd like to change setup-python-poetry to install all extras
+        # by default, using e.g. an implementation of
+        # https://github.com/python-poetry/poetry/issues/3413
+        type: string
+        required: false
+        default: ""
 
 
 jobs:
@@ -33,6 +45,9 @@ jobs:
 
       - name: Setup Poetry
         uses: matrix-org/setup-python-poetry@v1
+        with:
+          # We want to make use of type hints in optional dependencies too.
+          extras: "${{ inputs.typechecking-extras }}"
 
       - name: Restore/persist mypy's cache
         uses: AustinScola/mypy-cache-github-action@v1


### PR DESCRIPTION
In https://github.com/matrix-org/synapse/pull/12531 I was bitten by a different mypy result in CI to my local environment. CI was running `poetry install`; I had run `poetry install --extras all` locally.

I had intended for poetry's development environment (its list of dev-dependencies) to be sufficient for all development tasks. But that ideal doesn't work well here. On reflection, let's allow this action to install a list of extras _for typechecking only_.

Proof that this works: https://github.com/matrix-org/synapse/runs/6156325285?check_suite_focus=true#step:3:3 shows that we pass the extras through to `setup-python-poetry`.

Once merged, I'll do a minor release (1.3.0) and forward the v1 tag.