### PR TITLE
Add sign-off workflow

### DIFF
--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -1,0 +1,50 @@
+name: Contribution requirements
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+  workflow_call:
+
+jobs:
+  signoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR for sign-off text
+        uses: actions/github-script@v6
+        with:
+          script: |
+            // We don't require owners or members of the org to sign off.
+            const authorAssociation = context.payload.pull_request.author_association;
+            if (['OWNER', 'MEMBER'].includes(authorAssociation) ||
+                // GitHub sometimes mislables users as 'CONTRIBUTOR'/'COLLABORATOR',
+                // so check that the user created the PR on the base project to check they have write access.
+                context.payload.pull_request.head.user.login === context.repo.owner) {
+              core.notice('Pull request does not require sign-off.');
+              return;
+            }
+
+            // This regex is intentionally left lenient.
+            const signOffRegex = /signed[_\- ]off[_\- ]by: [\w ]+ <.+(@|at).+>/i;
+
+            if (signOffRegex.test(context.payload.pull_request.body ?? "")) {
+              core.notice('Pull request body contains a sign-off notice');
+              return;
+            }
+
+            const commits = await github.rest.pulls.listCommits({
+              pull_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              // It's *possible* the author has buried the sign-off 101 commits down, but
+              // we don't want to max out the API searching for it.
+              per_page: 100,
+            });
+
+            const commit = commits.data.find(c => signOffRegex.test(c.commit.message));
+            if (commit) {
+              core.notice(`Commit '${commit.id}' contains a sign-off notice`);
+              return;
+            }
+
+            core.setFailed('No sign off found. Please ensure you have signed off following the advice in https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off.')
+            core.notice('If you have signed off privately instead (following the steps in Private Sign off), you can ignore this test.')


### PR DESCRIPTION
A clone of https://github.com/matrix-org/matrix-appservice-bridge/blob/develop/.github/workflows/sign-off.yml, with some better documentation and improvements to the "are they an org member" check.