### PR TITLE
sign-off: Fix link and add format advice

### DIFF
--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -46,5 +46,6 @@ jobs:
               return;
             }
 
-            core.setFailed('No sign off found. Please ensure you have signed off following the advice in https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off.')
+            core.setFailed('No sign off found. Please ensure you have signed off following the advice in https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off .')
+            core.notice('Ensure you have matched the format `Signed-off-by: Your Name <your@email.example.org>`')
             core.notice('If you have signed off privately instead (following the steps in Private Sign off), you can ignore this test.')


### PR DESCRIPTION
As found in https://github.com/matrix-org/matrix-hookshot/pull/430, the linkifying in GitHub included the `.` and so the anchor didn't work.

Also, it turns out people sometimes miss the format we expect and do their own thing. Rather than trying to make the regex even more lenient, I'd rather just suggest the format we expect explicitly.