### PR TITLE
Use `GITHUB_OUTPUT` in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
                   tag=${GITHUB_SHA}
                   ;;
           esac
-          echo "::set-output name=tag::$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Build and push images
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Deals with GHA deprecations, see
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/