### PR TITLE
Suppress the update check in the ruff linter.

### DIFF
--- a/.github/workflows/python-poetry-ci.yml
+++ b/.github/workflows/python-poetry-ci.yml
@@ -34,7 +34,8 @@ jobs:
         run: poetry run black --check --diff .
 
       - name: Semantic checks (ruff)
-        run: poetry run ruff .
+        # --quiet suppresses the update check.
+        run: poetry run ruff --quiet .
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Per matrix-org/synapse#14741 there's no reason to do this in CI.