### PR TITLE
Make sign-off regex more leniant

### DIFF
--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -24,7 +24,7 @@ jobs:
             }
 
             // This regex is intentionally left lenient.
-            const signOffRegex = /signed[_\- ]off[_\- ]by: [\w ]+ <.+(@|at).+>/i;
+            const signOffRegex = /signed[_\- ]off[_\- ]by: [\S ]+ <?.+(@|at).+>?/i;
 
             if (signOffRegex.test(context.payload.pull_request.body ?? "")) {
               core.notice('Pull request body contains a sign-off notice');


### PR DESCRIPTION
This changes the sign off checker to stop assuming everyone's name is matched by `[\w ]+`. (*cough* https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/ *cough*).

Instead, we're just going to check for the absence of whitespace and assume that reviewers will do a visual test to make sure the name *looks* okay. 

Also dropping the requirement for < and > to wrap the email, as not everyone does it and I don't think it's a hard requirement.